### PR TITLE
Fixed the comment to the correct metric name for async scaling

### DIFF
--- a/async-inference/Async-Inference-Walkthrough-SageMaker-Python-SDK.ipynb
+++ b/async-inference/Async-Inference-Walkthrough-SageMaker-Python-SDK.ipynb
@@ -375,7 +375,7 @@
     "    ScalableDimension=\"sagemaker:variant:DesiredInstanceCount\",  # SageMaker supports only Instance Count\n",
     "    PolicyType=\"TargetTrackingScaling\",  # 'StepScaling'|'TargetTrackingScaling'\n",
     "    TargetTrackingScalingPolicyConfiguration={\n",
-    "        \"TargetValue\": 5.0,  # The target value for the metric. - here the metric is - SageMakerVariantInvocationsPerInstance\n",
+    "        \"TargetValue\": 5.0,  # The target value for the metric. - here the metric is - ApproximateBacklogSizePerInstance\n",
     "        \"CustomizedMetricSpecification\": {\n",
     "            \"MetricName\": \"ApproximateBacklogSizePerInstance\",\n",
     "            \"Namespace\": \"AWS/SageMaker\",\n",

--- a/async-inference/Async-Inference-Walkthrough.ipynb
+++ b/async-inference/Async-Inference-Walkthrough.ipynb
@@ -404,7 +404,7 @@
     "    ScalableDimension=\"sagemaker:variant:DesiredInstanceCount\",  # SageMaker supports only Instance Count\n",
     "    PolicyType=\"TargetTrackingScaling\",  # 'StepScaling'|'TargetTrackingScaling'\n",
     "    TargetTrackingScalingPolicyConfiguration={\n",
-    "        \"TargetValue\": 5.0,  # The target value for the metric. - here the metric is - SageMakerVariantInvocationsPerInstance\n",
+    "        \"TargetValue\": 5.0,  # The target value for the metric. - here the metric is - ApproximateBacklogSizePerInstance\n",
     "        \"CustomizedMetricSpecification\": {\n",
     "            \"MetricName\": \"ApproximateBacklogSizePerInstance\",\n",
     "            \"Namespace\": \"AWS/SageMaker\",\n",


### PR DESCRIPTION
I fixed the comment for the metric because the metric for scaling async inference is "ApproximateBacklogSizePerInstance" and not "SageMakerVariantInvocationsPerInstance" (which is used for sync scaling)